### PR TITLE
Using cufft and streams

### DIFF
--- a/2D_Program/Makefile
+++ b/2D_Program/Makefile
@@ -28,7 +28,7 @@ endif
 ifneq ($(origin USE_CUFFTW), undefined)
 	ifneq ($(USE_CUFFTW), 0)
 		CFLAGS += -DUSE_CUFFTW
-		LIBS += -lcufft -lcufftw -lcudart
+		LIBS += -lcufft -lcudart
 	else
 		LIBS += -lfftw3_omp -lfftw3
 	endif

--- a/2D_Program/solver_functions/DST.c
+++ b/2D_Program/solver_functions/DST.c
@@ -8,44 +8,81 @@
 #if USE_CUFFTW
 #ifdef USE_COMBINE
 void fullDST( const cudaStream_t *streams,
+              const cudaEvent_t * events,
               const System        sys,
               const DSTN          dst,
-              const fftw_plan     plan,
-              const fftw_plan     plan2,
+              const cufftHandle   plan,
+              cuDoubleComplex *   d_workspace[2],
               cuDoubleComplex *   d_y,
               double *            in,
               fftw_complex *      out,
               double *            in2,
               fftw_complex *      out2 ) {
 
-    PUSH_RANGE( "forwardDST", 2 )
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[0] ) );
-    load_1st_DST_wrapper( sys, dst, sys.rhs, in, in2 );
+    PUSH_RANGE( "1st DST", 2 )
+    CUDA_RT_CALL( cudaEventRecord( events[2], streams[2] ) );
 
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[1] ) );
-    fftw_execute( plan );  /********************* FFTW *********************/
-    fftw_execute( plan2 ); /********************* FFTW *********************/
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan creation
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 creation
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.rhs
+
+    load_1st_DST_wrapper( streams[0], sys, dst, sys.rhs, in, in2 );
+
+    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
+
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for load_1st_DST
+    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );
+    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
+
+    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
+    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
+
+    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
+    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
+    CUDA_RT_CALL( cudaEventRecord( events[2], streams[3] ) );
     POP_RANGE
 
-    PUSH_RANGE( "forwardDST", 3 )
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[2] ) );
-    middle_stuff_ls_DST_wrapper( sys, dst, out, out2, in, in2, d_y );
+    PUSH_RANGE( "Trig Solver", 3 )
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait forsys.U, sys.L, sys.Up
+
+    middle_stuff_ls_DST_wrapper( streams[0], sys, dst, out, out2, in, in2, d_y );
+
+    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
     POP_RANGE
 
-    PUSH_RANGE( "forwardDST", 4 )
-    fftw_execute( plan );  /********************* FFTW *********************/
-    fftw_execute( plan2 ); /********************* FFTW *********************/
+    PUSH_RANGE( "2nd DST", 4 )
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for middle_stuff_ls_DST
+    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );
 
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[3] ) );
-    store_2st_DST_wrapper( sys, dst, out, out2, sys.sol );
+    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
+
+    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
+    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
+
+    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
+    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
+    CUDA_RT_CALL( cudaEventRecord( events[2], streams[4] ) );
+
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.sol
+    store_2st_DST_wrapper( streams[0], sys, dst, out, out2, sys.sol );
+
+    CUDA_RT_CALL( cudaStreamSynchronize( streams[0] ) );  // Wait for store_2st_DST
     POP_RANGE
 }
 #else
 void fullDST( const cudaStream_t *streams,
+              const cudaEvent_t * events,
               const System        sys,
               const DSTN          dst,
-              const fftw_plan     plan,
-              const fftw_plan     plan2,
+              const cufftHandle   plan,
               cuDoubleComplex *   d_rhat,
               cuDoubleComplex *   d_xhat,
               cuDoubleComplex *   d_y,
@@ -54,28 +91,26 @@ void fullDST( const cudaStream_t *streams,
               double *            in2,
               fftw_complex *      out2 ) {
 
-    PUSH_RANGE( "forwardDST", 2 )
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[0] ) );
-    load_1st_DST_wrapper( sys, dst, sys.rhs, in, in2 );
+    PUSH_RANGE( "1st DST", 2 )
+    load_1st_DST_wrapper( NULL, sys, dst, sys.rhs, in, in2 );
 
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[1] ) );
-    fftw_execute( plan );  /********************* FFTW *********************/
-    fftw_execute( plan2 ); /********************* FFTW *********************/
-    store_1st_DST_wrapper( sys, dst, out, out2, d_rhat );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );    // Running in streams[0]
+    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
+
+    store_1st_DST_wrapper( NULL, sys, dst, out, out2, d_rhat );
     POP_RANGE
 
-    PUSH_RANGE( "forwardDST", 3 )
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[2] ) );
-    middle_stuff_DST_wrapper( sys, d_rhat, d_xhat, d_y );
+    PUSH_RANGE( "Trig Solver", 3 )
+    middle_stuff_DST_wrapper( NULL, sys, d_rhat, d_xhat, d_y );
     POP_RANGE
 
-    PUSH_RANGE( "forwardDST", 4 )
-    CUDA_RT_CALL( cudaStreamSynchronize( streams[3] ) );
-    load_2st_DST_wrapper( sys, dst, d_xhat, in, in2 );
-    fftw_execute( plan );  /********************* FFTW *********************/
-    fftw_execute( plan2 ); /********************* FFTW *********************/
+    PUSH_RANGE( "2nd DST", 4 )
+    load_2st_DST_wrapper( NULL, sys, dst, d_xhat, in, in2 );
 
-    store_2st_DST_wrapper( sys, dst, out, out2, sys.sol );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );    // Running in streams[0]
+    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
+
+    store_2st_DST_wrapper( NULL, sys, dst, out, out2, sys.sol );
     POP_RANGE
 }
 #endif

--- a/2D_Program/solver_functions/DST.c
+++ b/2D_Program/solver_functions/DST.c
@@ -12,67 +12,28 @@ void fullDST( const cudaStream_t *streams,
               const System        sys,
               const DSTN          dst,
               const cufftHandle   plan,
-              cuDoubleComplex *   d_workspace[2],
               cuDoubleComplex *   d_y,
               double *            in,
-              fftw_complex *      out,
-              double *            in2,
-              fftw_complex *      out2 ) {
+              fftw_complex *      out ) {
 
     PUSH_RANGE( "1st DST", 2 )
-    CUDA_RT_CALL( cudaEventRecord( events[2], streams[2] ) );
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for sys.rhs
 
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan creation
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 creation
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.rhs
-
-    load_1st_DST_wrapper( streams[0], sys, dst, sys.rhs, in, in2 );
-
-    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
-
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for load_1st_DST
-    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );
-    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
+    load_1st_DST_wrapper( streams[0], sys, dst, sys.rhs, in );
     CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
-
-    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
-    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
-    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
-
-    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
-    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
-    CUDA_RT_CALL( cudaEventRecord( events[2], streams[3] ) );
     POP_RANGE
 
     PUSH_RANGE( "Trig Solver", 3 )
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
     CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait forsys.U, sys.L, sys.Up
 
-    middle_stuff_ls_DST_wrapper( streams[0], sys, dst, out, out2, in, in2, d_y );
-
-    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
+    middle_stuff_ls_DST_wrapper( streams[0], sys, dst, out, in, d_y );
     POP_RANGE
 
     PUSH_RANGE( "2nd DST", 4 )
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for middle_stuff_ls_DST
-    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );
-
-    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
     CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
 
-    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
-    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
-    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
-
-    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
-    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
-    CUDA_RT_CALL( cudaEventRecord( events[2], streams[4] ) );
-
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
-    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.sol
-    store_2st_DST_wrapper( streams[0], sys, dst, out, out2, sys.sol );
+    CUDA_RT_CALL( cudaStreamWaitEvent( streams[3], events[3], cudaEventWaitDefault ) );  // Wait for sys.sol
+    store_2st_DST_wrapper( streams[0], sys, dst, out, sys.sol );
 
     CUDA_RT_CALL( cudaStreamSynchronize( streams[0] ) );  // Wait for store_2st_DST
     POP_RANGE
@@ -87,17 +48,13 @@ void fullDST( const cudaStream_t *streams,
               cuDoubleComplex *   d_xhat,
               cuDoubleComplex *   d_y,
               double *            in,
-              fftw_complex *      out,
-              double *            in2,
-              fftw_complex *      out2 ) {
+              fftw_complex *      out ) {
 
     PUSH_RANGE( "1st DST", 2 )
-    load_1st_DST_wrapper( NULL, sys, dst, sys.rhs, in, in2 );
+    load_1st_DST_wrapper( NULL, sys, dst, sys.rhs, in );
 
-    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );    // Running in streams[0]
-    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
-
-    store_1st_DST_wrapper( NULL, sys, dst, out, out2, d_rhat );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
+    store_1st_DST_wrapper( NULL, sys, dst, out, d_rhat );
     POP_RANGE
 
     PUSH_RANGE( "Trig Solver", 3 )
@@ -105,12 +62,10 @@ void fullDST( const cudaStream_t *streams,
     POP_RANGE
 
     PUSH_RANGE( "2nd DST", 4 )
-    load_2st_DST_wrapper( NULL, sys, dst, d_xhat, in, in2 );
+    load_2st_DST_wrapper( NULL, sys, dst, d_xhat, in );
 
-    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );    // Running in streams[0]
-    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]
-
-    store_2st_DST_wrapper( NULL, sys, dst, out, out2, sys.sol );
+    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]
+    store_2st_DST_wrapper( NULL, sys, dst, out, sys.sol );
     POP_RANGE
 }
 #endif

--- a/2D_Program/solver_functions/cuda_kernels.h
+++ b/2D_Program/solver_functions/cuda_kernels.h
@@ -6,23 +6,37 @@
 extern "C" {
 #endif
 
-void load_1st_DST_wrapper( const System sys, const DSTN dst, const cuDoubleComplex *d_rhs, double *in, double *in2 );
-void store_1st_DST_wrapper( const System           sys,
+void load_1st_DST_wrapper( const cudaStream_t     streams,
+                           const System           sys,
+                           const DSTN             dst,
+                           const cuDoubleComplex *d_rhs,
+                           double *               in,
+                           double *               in2 );
+void store_1st_DST_wrapper( const cudaStream_t     streams,
+                            const System           sys,
                             const DSTN             dst,
                             const cuDoubleComplex *out,
                             const cuDoubleComplex *out2,
                             cuDoubleComplex *      d_rhat );
-void load_2st_DST_wrapper( const System sys, const DSTN dst, const cuDoubleComplex *d_xhat, double *in, double *in2 );
-void store_2st_DST_wrapper( const System           sys,
+void load_2st_DST_wrapper( const cudaStream_t     streams,
+                           const System           sys,
+                           const DSTN             dst,
+                           const cuDoubleComplex *d_xhat,
+                           double *               in,
+                           double *               in2 );
+void store_2st_DST_wrapper( const cudaStream_t     streams,
+                            const System           sys,
                             const DSTN             dst,
                             const cuDoubleComplex *out,
                             const cuDoubleComplex *out2,
                             cuDoubleComplex *      d_sol );
-void middle_stuff_DST_wrapper( System                 sys,
+void middle_stuff_DST_wrapper( const cudaStream_t     streams,
+                               System                 sys,
                                const cuDoubleComplex *d_rhat,
                                cuDoubleComplex *      d_xhat,
                                cuDoubleComplex *      d_y );
-void middle_stuff_ls_DST_wrapper( System                 sys,
+void middle_stuff_ls_DST_wrapper( const cudaStream_t     streams,
+                                  System                 sys,
                                   const DSTN             dst,
                                   const cuDoubleComplex *out,
                                   const cuDoubleComplex *out2,

--- a/2D_Program/solver_functions/cuda_kernels.h
+++ b/2D_Program/solver_functions/cuda_kernels.h
@@ -10,25 +10,21 @@ void load_1st_DST_wrapper( const cudaStream_t     streams,
                            const System           sys,
                            const DSTN             dst,
                            const cuDoubleComplex *d_rhs,
-                           double *               in,
-                           double *               in2 );
+                           double *               in );
 void store_1st_DST_wrapper( const cudaStream_t     streams,
                             const System           sys,
                             const DSTN             dst,
                             const cuDoubleComplex *out,
-                            const cuDoubleComplex *out2,
                             cuDoubleComplex *      d_rhat );
 void load_2st_DST_wrapper( const cudaStream_t     streams,
                            const System           sys,
                            const DSTN             dst,
                            const cuDoubleComplex *d_xhat,
-                           double *               in,
-                           double *               in2 );
+                           double *               in );
 void store_2st_DST_wrapper( const cudaStream_t     streams,
                             const System           sys,
                             const DSTN             dst,
                             const cuDoubleComplex *out,
-                            const cuDoubleComplex *out2,
                             cuDoubleComplex *      d_sol );
 void middle_stuff_DST_wrapper( const cudaStream_t     streams,
                                System                 sys,
@@ -39,9 +35,7 @@ void middle_stuff_ls_DST_wrapper( const cudaStream_t     streams,
                                   System                 sys,
                                   const DSTN             dst,
                                   const cuDoubleComplex *out,
-                                  const cuDoubleComplex *out2,
                                   double *               in,
-                                  double *               in2,
                                   cuDoubleComplex *      d_y );
 
 #ifdef __cplusplus

--- a/2D_Program/solver_functions/solver.c
+++ b/2D_Program/solver_functions/solver.c
@@ -94,15 +94,6 @@ void solver( System sys ) {
     CUDA_RT_CALL( cudaMemsetAsync( out, size_out, 0, NULL ) );
     CUDA_RT_CALL( cudaMemsetAsync( out2, size_out, 0, NULL ) );
 
-    // The code should be here, BUT there's a bug in cuFFT
-    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.rhs, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[2] ) );
-
-    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.U, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
-    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.L, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
-    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.Up, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
-
-    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.sol, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[4] ) );
-
     /**********************BATCHED***************************/
     int  rank    = 1; /* not 2: we are computing 1d transforms */
     int  n[]     = { N };
@@ -135,9 +126,17 @@ void solver( System sys ) {
     CUDA_RT_CALL( cufftCreate( &plan ) );
     CUDA_RT_CALL( cufftMakePlanMany(
         plan, rank, n, inembed, istride, idist, onembed, ostride, odist, CUFFT_D2Z, howmany, &workspace ) );
-
 #endif
     POP_RANGE
+
+    // The code should be here, BUT there's a bug in cuFFT
+    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.rhs, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[2] ) );
+
+    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.U, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
+    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.L, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
+    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.Up, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[3] ) );
+
+    CUDA_RT_CALL( cudaMemPrefetchAsync( sys.sol, sys.lat.Nxy * sizeof( double _Complex ), 0, streams[4] ) );
 
     PUSH_RANGE( "DST", 5 )
 #ifdef USE_COMBINE


### PR DESCRIPTION
```C
    PUSH_RANGE( "1st DST", 2 )
    CUDA_RT_CALL( cudaEventRecord( events[2], streams[2] ) );

    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan creation
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 creation
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.rhs

    load_1st_DST_wrapper( streams[0], sys, dst, sys.rhs, in, in2 );

    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );

    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for load_1st_DST
    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );
    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]

    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]

    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
    CUDA_RT_CALL( cudaEventRecord( events[2], streams[3] ) );
    POP_RANGE

    PUSH_RANGE( "Trig Solver", 3 )
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait forsys.U, sys.L, sys.Up

    middle_stuff_ls_DST_wrapper( streams[0], sys, dst, out, out2, in, in2, d_y );

    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
    POP_RANGE

    PUSH_RANGE( "2nd DST", 4 )
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[1], events[0], cudaEventWaitDefault ) );  // Wait for middle_stuff_ls_DST
    CUDA_RT_CALL( cufftSetStream( plan, streams[0] ) );

    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[0] ) );
    CUDA_RT_CALL( cufftExecD2Z( plan, in, out ) );  // Running in streams[0]

    CUDA_RT_CALL( cufftSetStream( plan, streams[1] ) );
    CUDA_RT_CALL( cufftSetWorkArea( plan, d_workspace[1] ) );
    CUDA_RT_CALL( cufftExecD2Z( plan, in2, out2 ) );  // Running in streams[1]

    CUDA_RT_CALL( cudaEventRecord( events[0], streams[0] ) );
    CUDA_RT_CALL( cudaEventRecord( events[1], streams[1] ) );
    CUDA_RT_CALL( cudaEventRecord( events[2], streams[4] ) );

    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[0], cudaEventWaitDefault ) );  // Wait for plan execution
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[1], cudaEventWaitDefault ) );  // Wait for plan2 execution
    CUDA_RT_CALL( cudaStreamWaitEvent( streams[0], events[2], cudaEventWaitDefault ) );  // Wait for sys.sol
    store_2st_DST_wrapper( streams[0], sys, dst, out, out2, sys.sol );

    CUDA_RT_CALL( cudaStreamSynchronize( streams[0] ) );  // Wait for store_2st_DST
    POP_RANGE
```